### PR TITLE
Add build support for Visual Studio/MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ debug_bin/
 
 # Dunno
 *.qm
+
+# Visual Studio
+.vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,14 +62,15 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 
 
 # Things to always include as flags. Change as needed.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Wno-sign-compare -Wno-unused-parameter")  
-# Build-type specific flags. Change as needed.
-SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-if(MINGW)
-    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wl,-subsystem,windows")
+if (NOT MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Wno-sign-compare -Wno-unused-parameter")  
+    # Build-type specific flags. Change as needed.
+    SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+    if(MINGW)
+        SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wl,-subsystem,windows")
+        SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
+    endif()
 endif()
-
-SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 
 
 message(STATUS "Building with the following extra flags: ${CMAKE_CXX_FLAGS}")
@@ -93,7 +94,7 @@ add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
 ## Windows API Stuff
 find_library (PSAPI Psapi)
 
-if(MINGW)
+if(WIN32)
     SET(WINDOWS_ICON_RESOURCE "${PROJECT_SOURCE_DIR}/resources/app_icon.rc")
 endif()
 
@@ -107,14 +108,23 @@ qt5_add_resources(QT5_RESOURCES "${PROJECT_SOURCE_DIR}/resources/Icons.qrc")
 # Compile all sources into a library. Called engine here (change if you wish).
 
 add_library(${MAIN_LIBRARY_NAME} SHARED ${SOURCES} )
-target_link_libraries(${MAIN_LIBRARY_NAME} PSAPI stdc++fs)
-
+target_link_libraries(${MAIN_LIBRARY_NAME} PSAPI)
+if (MSVC)
+    target_compile_options(
+        ${MAIN_LIBRARY_NAME} PUBLIC 
+        "/std:c++17" 
+        "/permissive-"
+    )
+endif()
+if (NOT MSVC)
+    target_link_libraries(${MAIN_LIBRARY_NAME} PUBLIC stdc++fs)
+endif()
 # Add an executable for the file main.cpp, here called main.x.
 # If you add more executables, copy these three lines accordingly.
 
 add_executable(${PROJECT_NAME} ${APPFILES} ${QT5_RESOURCES} ${WINDOWS_ICON_RESOURCE})
 add_dependencies(${PROJECT_NAME} ${MAIN_LIBRARY_NAME})     
-target_link_libraries(${PROJECT_NAME} stdc++fs ${MAIN_LIBRARY_NAME} Qt5::Widgets)
+target_link_libraries(${PROJECT_NAME} ${MAIN_LIBRARY_NAME} Qt5::Widgets)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${MAIN_APP_NAME})
 
@@ -126,7 +136,7 @@ add_custom_command(
     COMMAND python "${SCRIPTS_DIR}/GenerateJson.py" --source "${SCRIPTS_DIR}/MHW Layered Armor.xlsx" --dest "${CMAKE_BINARY_DIR}/ArmorData.json" )
 
 # Deploy QT on Windows
-if(MINGW AND CMAKE_BUILD_TYPE STREQUAL "Release")
+if(WIN32 AND CMAKE_BUILD_TYPE STREQUAL "Release")
     set(EXPORT_LIB_DIR "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins")
     add_custom_command(
         TARGET ${PROJECT_NAME}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,8 @@ if (NOT MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wpedantic -Wextra -Wno-sign-compare -Wno-unused-parameter")  
     # Build-type specific flags. Change as needed.
     SET(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
-    if(MINGW)
-        SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wl,-subsystem,windows")
-        SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
-    endif()
+    SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wl,-subsystem,windows")
+    SET(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
 endif()
 
 
@@ -94,9 +92,7 @@ add_definitions(-DELPP_NO_DEFAULT_LOG_FILE)
 ## Windows API Stuff
 find_library (PSAPI Psapi)
 
-if(WIN32)
-    SET(WINDOWS_ICON_RESOURCE "${PROJECT_SOURCE_DIR}/resources/app_icon.rc")
-endif()
+SET(WINDOWS_ICON_RESOURCE "${PROJECT_SOURCE_DIR}/resources/app_icon.rc")
 
 # QT5 Resources
 qt5_add_resources(QT5_RESOURCES "${PROJECT_SOURCE_DIR}/resources/Icons.qrc")
@@ -108,16 +104,22 @@ qt5_add_resources(QT5_RESOURCES "${PROJECT_SOURCE_DIR}/resources/Icons.qrc")
 # Compile all sources into a library. Called engine here (change if you wish).
 
 add_library(${MAIN_LIBRARY_NAME} SHARED ${SOURCES} )
-target_link_libraries(${MAIN_LIBRARY_NAME} PSAPI)
 if (MSVC)
+    target_link_libraries(
+        ${MAIN_LIBRARY_NAME} PUBLIC 
+        PSAPI
+    )
     target_compile_options(
         ${MAIN_LIBRARY_NAME} PUBLIC 
         "/std:c++17" 
         "/permissive-"
     )
-endif()
-if (NOT MSVC)
-    target_link_libraries(${MAIN_LIBRARY_NAME} PUBLIC stdc++fs)
+else()
+    target_link_libraries(
+        ${MAIN_LIBRARY_NAME} PUBLIC 
+        PSAPI 
+        stdc++fs
+    )
 endif()
 # Add an executable for the file main.cpp, here called main.x.
 # If you add more executables, copy these three lines accordingly.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,10 @@ if (MSVC)
         "/std:c++17" 
         "/permissive-"
     )
+    target_compile_definitions(
+        ${MAIN_LIBRARY_NAME} PUBLIC
+        NOMINMAX=1
+    )
 else()
     target_link_libraries(
         ${MAIN_LIBRARY_NAME} PUBLIC 
@@ -126,7 +130,11 @@ endif()
 
 add_executable(${PROJECT_NAME} ${APPFILES} ${QT5_RESOURCES} ${WINDOWS_ICON_RESOURCE})
 add_dependencies(${PROJECT_NAME} ${MAIN_LIBRARY_NAME})     
-target_link_libraries(${PROJECT_NAME} ${MAIN_LIBRARY_NAME} Qt5::Widgets)
+if (MSVC)
+    target_link_libraries(${PROJECT_NAME} ${MAIN_LIBRARY_NAME} Qt5::Widgets)
+else()
+    target_link_libraries(${PROJECT_NAME} stdc++fs ${MAIN_LIBRARY_NAME} Qt5::Widgets)
+endif()
 
 set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME ${MAIN_APP_NAME})
 

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,23 @@
+﻿{
+    "configurations": [
+        {
+            "name": "x64-Debug",
+            "generator": "Ninja",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${projectDir}/build"
+        },
+        {
+            "name": "x64-Release",
+            "generator": "Ninja",
+            "inheritEnvironments": [ "msvc_x64_x64" ],
+            "buildRoot": "${projectDir}/build",
+            "cmakeCommandArgs": "",
+            "variables": [
+                {
+                    "name": "CMAKE_BUILD_TYPE",
+                    "value": "Release"
+                }
+            ]
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -36,19 +36,21 @@ Checkout the compiled binaries on the latest [Release](https://github.com/alcros
 ![](Preview/preview1.png)
 ![](Preview/preview2.png)
 
-# Building Using MinGW
-
-## Depndencies To Build
-
+# Dependencies To Build
 * CMake # [Download Link!](https://cmake.org/download/)
 * QT5 (Select MinGW 7.30)# [Download Link!](https://www.qt.io/download)
-* MinGW 64bits # Because I'm using std::filesystem, the only compiler that works is MinGW from Msys2, I apologize.
-* Msys2 # [Download Link!](http://www.msys2.org/)
+* Python 3 and `openpyxl` (`pip install openpyxl`)
 
-### Logging powered by EasyLogging++
+
+## Logging powered by EasyLogging++
 [Available here](https://github.com/zuhd-org/easyloggingpp)
 
 Sorry I'm to lazy to do the git submodule sutff.
+
+
+## Building Using MinGW
+* MinGW 64bits 
+* Msys2 # [Download Link!](http://www.msys2.org/)
 
 ### Installation of MinGW using Msys2
 * Install Msys2 (I recommend installing it on the root of C: drive)
@@ -71,10 +73,17 @@ $ cmake .. -DCMAKE_BUILD_TYPE=[Debug | Release] -G "MinGW Makefiles"
 $ mingw32-make
 ```
 
-# Building Using Visual Studio
-Pending...
- 
+## Building Using Visual Studio
+* Visual Studio 2017
+* Have MSVC x64 in your Qt install
 
+Build either with CMake directly, or use File > Open > CMake in Visual 
+Studio, then select Debug or Release, and press build.
 
-
+### Directly with CMake
+```cmake
+mkdir build && cd build
+cmake .. -DCMAKE_BUILD_TYPE=[Debug | Release] -G "Visual Studio 15 2017 Win64"
+cmake --build . --config [Debug | Release]
+```
 

--- a/app/DialogWindow.hpp
+++ b/app/DialogWindow.hpp
@@ -3,6 +3,8 @@
 #include "ui_DialogWindow.h"
 
 #include <QInputDialog>
+#include <array>
+#include <string>
 
 namespace Status
 {

--- a/include/Process.hpp
+++ b/include/Process.hpp
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 #include <iostream>
-
+#define NOMINMAX
 #include <windows.h>
 #include <tlhelp32.h>
 #include <psapi.h>

--- a/include/Process.hpp
+++ b/include/Process.hpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <vector>
 #include <iostream>
-#define NOMINMAX
 #include <windows.h>
 #include <tlhelp32.h>
 #include <psapi.h>


### PR DESCRIPTION
Since Visual Studio does support std::filesystem, I just needed to clean up the CMakeLists and fix some small problems that occured when compiling. 

I also did some cleaning in README to reflect build support.

I have not tested if this breaks MinGW compilation, due to not having it installed. It *shouldn't*, but I don't know. Please do test that before merging. 🙂 